### PR TITLE
DPI-2845 Package d3vennR in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,13 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "d3vennR";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''Make interactive d3.js Venn/Euler diagrams in R with the convenience and infrastructure
+              of an htmlwidget.'';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    htmlwidgets
+ ];
+
+}

--- a/package.nix
+++ b/package.nix
@@ -5,9 +5,8 @@ pkgs.rPackages.buildRPackage {
   version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
   src = ./.;
   description = ''Make interactive d3.js Venn/Euler diagrams in R with the convenience and infrastructure
-              of an htmlwidget.'';
+    of an htmlwidget.'';
   propagatedBuildInputs = with pkgs.rPackages; [ 
     htmlwidgets
- ];
-
+  ];
 }


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package d3vennR in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR